### PR TITLE
filesizeformat implementation as well as localized filesize

### DIFF
--- a/templates/defaultfilters/defaultfilters.h
+++ b/templates/defaultfilters/defaultfilters.h
@@ -67,6 +67,7 @@ public:
     filters.insert(QStringLiteral("first"), new FirstFilter());
     filters.insert(QStringLiteral("fix_ampersands"), new FixAmpersandsFilter());
     filters.insert(QStringLiteral("floatformat"), new FloatFormatFilter());
+    filters.insert(QStringLiteral("filesizeformat"), new FileSizeFormatFilter());
     filters.insert(QStringLiteral("force_escape"), new ForceEscapeFilter());
     filters.insert(QStringLiteral("get_digit"), new GetDigitFilter());
     filters.insert(QStringLiteral("join"), new JoinFilter());

--- a/templates/defaultfilters/stringfilters.cpp
+++ b/templates/defaultfilters/stringfilters.cpp
@@ -476,3 +476,84 @@ QVariant SlugifyFilter::doFilter(const QVariant &input,
           .replace(QRegularExpression(QStringLiteral("[-\\s]+")), QStringLiteral("-"));
   return SafeString(inputString, true);
 }
+
+QVariant FileSizeFormatFilter::doFilter(const QVariant &input,
+                                        const QVariant &argument,
+                                        bool autoescape) const
+{
+  QVariant ret;
+
+  Q_UNUSED(autoescape)
+  const auto arg = getSafeString(argument);
+  bool numberConvert = true;
+
+  qreal size = 0.0f;
+  if (input.canConvert<qreal>()) {
+      size = input.toReal(&numberConvert);
+      if (!numberConvert) {
+          qWarning("%s", "Failed to convert input file size into floating point value.");
+      }
+  } else {
+      size = getSafeString(input).get().toDouble(&numberConvert);
+      if (!numberConvert) {
+          qWarning("%s", "Failed to convert input file size into floating point value.");
+      }
+  }
+
+  int unitSystem = 10;
+  int precision = 2;
+  qreal multiplier = 1.0f;
+
+  if (!arg.get().isEmpty()) {
+      const auto argList = arg.get().split(QLatin1Char(','), QString::SkipEmptyParts);
+      const auto numArgs = argList.size();
+      if (numArgs > 0) {
+          unitSystem = argList.at(0).toInt(&numberConvert);
+          if (!numberConvert) {
+              qWarning("%s", "Failed to convert filse size format unit system into integer. Falling back to default 10.");
+              unitSystem = 10;
+          }
+      }
+
+      if (numArgs > 1) {
+          precision = argList.at(1).toInt(&numberConvert);
+          if (!numberConvert) {
+              qWarning("%s", "Failed to convert file size format decimal precision into integer. Falling back to default 2.");
+              precision = 2;
+          }
+      }
+
+      if (numArgs > 2) {
+          multiplier = argList.at(2).toDouble(&numberConvert);
+          if (!numberConvert) {
+              qWarning("%s", "Failed to convert file size format multiplier into double value. Falling back to default 1.0");
+              multiplier = 1.0f;
+          } else {
+              if (multiplier == 0.0f) {
+                  qWarning("%s", "It makes no sense to multiply the file size by zero. Using default value 1.0.");
+                  multiplier = 1.0f;
+              }
+          }
+      }
+  }
+
+  const double sizeMult = size * multiplier;
+
+  if (unitSystem == 10) {
+      if ((sizeMult > -1000) && (sizeMult < 1000)) {
+          precision = 0;
+      }
+  } else if (unitSystem == 2) {
+      if ((sizeMult > - 1024) && (sizeMult < 1024)) {
+          precision = 0;
+      }
+  }
+
+  const std::pair<qreal,QString> sizePair = calcFileSize(size, unitSystem, multiplier);
+
+  const QString retString = QString::number(sizePair.first, 'f', precision) + QLatin1Char(' ') + sizePair.second;
+
+  ret.setValue(retString);
+
+  return ret;
+}

--- a/templates/defaultfilters/stringfilters.h
+++ b/templates/defaultfilters/stringfilters.h
@@ -259,4 +259,14 @@ public:
   bool isSafe() const override { return true; }
 };
 
+class FileSizeFormatFilter : public Filter
+{
+public:
+  QVariant doFilter(const QVariant &input,
+                    const QVariant &argument = QVariant(),
+                    bool autoescape = {}) const override;
+
+  bool isSafe() const override { return true; }
+};
+
 #endif

--- a/templates/i18n/CMakeLists.txt
+++ b/templates/i18n/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(cutelee_i18ntags MODULE
   i18np.cpp
   i18ncp.cpp
   l10n_money.cpp
+  l10n_filesize.cpp
   with_locale.cpp
 )
 set_property(TARGET cutelee_i18ntags PROPERTY

--- a/templates/i18n/i18ntags.h
+++ b/templates/i18n/i18ntags.h
@@ -28,6 +28,7 @@
 #include "i18ncp.h"
 #include "i18np.h"
 #include "l10n_money.h"
+#include "l10n_filesize.h"
 #include "with_locale.h"
 
 namespace Cutelee
@@ -66,6 +67,10 @@ public:
                          new L10nMoneyNodeFactory());
     nodeFactories.insert(QStringLiteral("l10n_money_var"),
                          new L10nMoneyVarNodeFactory());
+    nodeFactories.insert(QStringLiteral("l10n_filesize"),
+                         new L10nFileSizeNodeFactory());
+    nodeFactories.insert(QStringLiteral("l10n_filesize_var"),
+                         new L10nFileSizeVarNodeFactory());
     nodeFactories.insert(QStringLiteral("with_locale"),
                          new WithLocaleNodeFactory());
     // TODO: Compat and block tags

--- a/templates/i18n/l10n_filesize.cpp
+++ b/templates/i18n/l10n_filesize.cpp
@@ -1,0 +1,237 @@
+/*
+ * This file is part of the Cutelee template system.
+ *
+ * Copyright (c) 2020 Matthias Fehring <mf@huessenbergnetz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the Licence, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "l10n_filesize.h"
+
+#include "abstractlocalizer.h"
+#include "engine.h"
+#include "exception.h"
+#include "parser.h"
+#include "template.h"
+#include "util.h"
+
+L10nFileSizeNodeFactory::L10nFileSizeNodeFactory() {}
+
+Node *L10nFileSizeNodeFactory::getNode(const QString &tagContent, Parser *p) const
+{
+    QStringList parts = smartSplit(tagContent);
+    parts.removeFirst(); // not interested in the name of the tag
+    if (parts.isEmpty()) {
+        throw Exception(TagSyntaxError, QStringLiteral("Error: l10n_filesize requires at least the file size as first parameter"));
+    }
+
+    FilterExpression size(parts.at(0), p);
+
+    FilterExpression unitSystem;
+    if (parts.size() > 1) {
+        unitSystem = FilterExpression(parts.at(1), p);
+    }
+
+    FilterExpression precision;
+    if (parts.size() > 2) {
+        precision = FilterExpression(parts.at(2), p);
+    }
+
+    FilterExpression multiplier;
+    if (parts.size() > 3) {
+        multiplier = FilterExpression(parts.at(3), p);
+    }
+
+    return new L10nFileSizeNode(size, unitSystem, precision, multiplier, p);
+}
+
+L10nFileSizeVarNodeFactory::L10nFileSizeVarNodeFactory() {}
+
+Node *L10nFileSizeVarNodeFactory::getNode(const QString &tagContent, Parser *p) const
+{
+  QStringList parts = smartSplit(tagContent);
+  parts.removeFirst(); // not interested in the name of the tag
+  if (parts.size() < 2) {
+      throw Exception(TagSyntaxError, QStringLiteral("Error: l10n_filesize_var tag takes at least 2 arguments, the file size and the variable name"));
+  }
+
+  FilterExpression size(parts.at(0), p);
+
+  FilterExpression unitSystem;
+  if (parts.size() > 2) {
+      unitSystem = FilterExpression(parts.at(1), p);
+  }
+
+  FilterExpression precision;
+  if (parts.size() > 3) {
+      precision = FilterExpression(parts.at(2), p);
+  }
+
+  FilterExpression multiplier;
+  if (parts.size() > 4) {
+      multiplier = FilterExpression(parts.at(3), p);
+  }
+
+  auto resultName = parts.last();
+
+  return new L10nFileSizeVarNode(size, unitSystem, precision, multiplier, resultName, p);
+}
+
+L10nFileSizeNode::L10nFileSizeNode(const FilterExpression &size,
+                                   const FilterExpression &unitSystem,
+                                   const FilterExpression &precision,
+                                   const FilterExpression &multiplier,
+                                   QObject *parent)
+    : Node(parent), m_size(size), m_unitSystem(unitSystem), m_precision(precision), m_multiplier(multiplier)
+{
+}
+
+void L10nFileSizeNode::render(OutputStream *stream, Context *c) const
+{
+    bool convertNumbers = true;
+
+    qreal size = 0.0f;
+    if (m_size.resolve(c).canConvert<qreal>()) {
+        size = m_size.resolve(c).toReal(&convertNumbers);
+    } else {
+        size = getSafeString(m_size.resolve(c)).get().toDouble(&convertNumbers);
+    }
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert input file size into a floating point number.");
+        return;
+    }
+
+    int unitSystem = m_unitSystem.isValid() ? m_unitSystem.resolve(c).toInt(&convertNumbers) : 10;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert unit system for file size into integer value. Using default decimal system as default.");
+        unitSystem = 10;
+    }
+
+    int precision = m_precision.isValid() ? m_precision.resolve(c).toInt(&convertNumbers) : 2;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert decimal precision for file size into an integer value. Using default value 2.");
+        precision = 2;
+    }
+
+    qreal multiplier = m_multiplier.isValid() ? m_multiplier.resolve(c).toReal(&convertNumbers) : 1.0f;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert multiplier file size into a floating point number. Using default value 1.0.");
+        multiplier = 1.0f;
+    }
+
+    if (multiplier == 0.0f) {
+        qWarning("%s", "It makes no sense to multiply the file size by zero. Using default value 1.0.");
+        multiplier = 1.0f;
+    }
+
+    const double sizeMult = size * multiplier;
+
+    if (unitSystem == 10) {
+        if ((sizeMult > -1000) && (sizeMult < 1000)) {
+            precision = 0;
+        }
+    } else if (unitSystem == 2) {
+        if ((sizeMult > - 1024) && (sizeMult < 1024)) {
+            precision = 0;
+        }
+    }
+
+    const std::pair<qreal,QString> fspair = calcFileSize(size, unitSystem, multiplier);
+
+    QString resultString;
+
+    if (precision == 2) {
+        resultString = c->localizer()->localizeNumber(fspair.first) + QChar(QChar::Space) + fspair.second;
+    } else {
+        QLocale l(c->localizer()->currentLocale());
+        resultString = l.toString(fspair.first, 'f', precision) + QChar(QChar::Space) + fspair.second;
+    }
+
+    streamValueInContext(stream, resultString, c);
+}
+
+L10nFileSizeVarNode::L10nFileSizeVarNode(const FilterExpression &size,
+                                         const FilterExpression &unitSystem,
+                                         const FilterExpression &precision,
+                                         const FilterExpression &multiplier,
+                                         const QString &resultName, QObject *parent)
+    : Node(parent), m_size(size), m_unitSystem(unitSystem), m_precision(precision), m_multiplier(multiplier),
+      m_resultName(resultName)
+{
+}
+
+void L10nFileSizeVarNode::render(OutputStream *stream, Context *c) const
+{
+    Q_UNUSED(stream)
+    bool convertNumbers = true;
+
+    qreal size = 0.0f;
+    if (m_size.resolve(c).canConvert<qreal>()) {
+        size = m_size.resolve(c).toReal(&convertNumbers);
+    } else {
+        size = getSafeString(m_size.resolve(c)).get().toDouble(&convertNumbers);
+    }
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert input file size into a floating point number.");
+        return;
+    }
+
+    int unitSystem = m_unitSystem.isValid() ? m_unitSystem.resolve(c).toInt(&convertNumbers) : 10;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert unit system for file size into integer value. Using default decimal system.");
+        unitSystem = 10;
+    }
+
+    int precision = m_precision.isValid() ? m_precision.resolve(c).toInt(&convertNumbers) : 2;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert decimal precision for file size into an integer value. Using default value 2.");
+        precision = 2;
+    }
+
+    qreal multiplier = m_multiplier.isValid() ? m_multiplier.resolve(c).toReal(&convertNumbers) : 1.0f;
+    if (!convertNumbers) {
+        qWarning("%s", "Failed to convert multiplier file size into a floating point number. Using default value 1.0.");
+        multiplier = 1.0f;
+    }
+
+    if (multiplier == 0.0f) {
+        qWarning("%s", "It makes no sense to mulitply the file size by zero. Using default value 1.0.");
+        multiplier = 1.0f;
+    }
+
+    const double sizeMult = size * multiplier;
+
+    if (unitSystem == 10) {
+        if ((sizeMult > -1000) && (sizeMult < 1000)) {
+            precision = 0;
+        }
+    } else if (unitSystem == 2) {
+        if ((sizeMult > - 1024) && (sizeMult < 1024)) {
+            precision = 0;
+        }
+    }
+
+    const std::pair<qreal,QString> fspair = calcFileSize(size, unitSystem, multiplier);
+
+    QString resultString;
+
+    if (precision == 2) {
+        resultString = c->localizer()->localizeNumber(fspair.first) + QChar(QChar::Space) + fspair.second;
+    } else {
+        QLocale l(c->localizer()->currentLocale());
+        resultString = l.toString(fspair.first, 'f', precision) + QChar(QChar::Space) + fspair.second;
+    }
+
+    c->insert(m_resultName, resultString);
+}

--- a/templates/i18n/l10n_filesize.h
+++ b/templates/i18n/l10n_filesize.h
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Cutelee template system.
+ *
+ * Copyright (c) 2020 Matthias Fehring <mf@huessenbergnetz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either version
+ * 2 of the Licence, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef L10N_FILESIZE_H
+#define L10N_FILESIZE_H
+
+#include "node.h"
+
+namespace Cutelee
+{
+    class Parser;
+}
+
+using namespace Cutelee;
+
+class L10nFileSizeNodeFactory : public AbstractNodeFactory
+{
+    Q_OBJECT
+public:
+    L10nFileSizeNodeFactory();
+
+    Node *getNode(const QString &tagContent, Parser *p) const override;
+};
+
+class L10nFileSizeVarNodeFactory : public AbstractNodeFactory
+{
+    Q_OBJECT
+public:
+    L10nFileSizeVarNodeFactory();
+
+    Node *getNode(const QString &tagContent, Parser *p) const override;
+};
+
+class L10nFileSizeNode : public Node
+{
+    Q_OBJECT
+public:
+    L10nFileSizeNode(const FilterExpression &size,
+                     const FilterExpression &unitSystem,
+                     const FilterExpression &precision,
+                     const FilterExpression &multiplier,
+                     QObject *parent = nullptr);
+
+    void render(OutputStream *stream, Context *c) const override;
+
+private:
+    FilterExpression m_size;
+    FilterExpression m_unitSystem;
+    FilterExpression m_precision;
+    FilterExpression m_multiplier;
+};
+
+class L10nFileSizeVarNode : public Node
+{
+    Q_OBJECT
+public:
+    L10nFileSizeVarNode(const FilterExpression &size,
+                        const FilterExpression &unitSystem,
+                        const FilterExpression &precision,
+                        const FilterExpression &multiplier,
+                        const QString &resultName,
+                        QObject *parent = nullptr);
+
+    void render(OutputStream *stream, Context *c) const override;
+
+private:
+    FilterExpression m_size;
+    FilterExpression m_unitSystem;
+    FilterExpression m_precision;
+    FilterExpression m_multiplier;
+    QString m_resultName;
+};
+
+#endif

--- a/templates/lib/util.cpp
+++ b/templates/lib/util.cpp
@@ -168,6 +168,90 @@ bool Cutelee::equals(const QVariant &lhs, const QVariant &rhs)
   return equal;
 }
 
+std::pair<qreal,QString> Cutelee::calcFileSize(qreal size, int unitSystem, qreal multiplier)
+{
+  std::pair<qreal,QString> ret;
+
+  int _unitSystem = unitSystem;
+
+  if ((_unitSystem != 2) && (_unitSystem != 10)) {
+      qWarning("%s", "Unrecognized file size unit system. Falling back to decimal unit system.");
+      _unitSystem = 10;
+  }
+
+  if (size == 0.0) {
+      ret.first = 0.0;
+      ret.second = QStringLiteral("bytes");
+      return ret;
+  } else if ((size == 1.0) || (size == -1.0)) {
+      ret.first = 1.0;
+      ret.second = QStringLiteral("byte");
+      return ret;
+  }
+
+  qreal _size = size * multiplier;
+
+  const bool positiveValue = (_size > 0);
+
+  if (!positiveValue) {
+      _size *= -1;
+  }
+
+  static const QStringList binaryUnits({
+                                           QStringLiteral("bytes"),
+                                           QStringLiteral("KiB"),
+                                           QStringLiteral("MiB"),
+                                           QStringLiteral("GiB"),
+                                           QStringLiteral("TiB"),
+                                           QStringLiteral("PiB"),
+                                           QStringLiteral("EiB"),
+                                           QStringLiteral("ZiB"),
+                                           QStringLiteral("YiB")
+                                       });
+
+  static const QStringList decimalUnits({
+                                           QStringLiteral("bytes"),
+                                           QStringLiteral("KB"),
+                                           QStringLiteral("MB"),
+                                           QStringLiteral("GB"),
+                                           QStringLiteral("TB"),
+                                           QStringLiteral("PB"),
+                                           QStringLiteral("EB"),
+                                           QStringLiteral("ZB"),
+                                           QStringLiteral("YB")
+                                       });
+
+  bool found = false;
+  int count = 0;
+  const qreal baseVal = (_unitSystem == 10) ? 1000.0f : 1024.0f;
+  qreal current = 1.0f;
+  int units = decimalUnits.size();
+  while (!found && (count < units)) {
+      current *= baseVal;
+      if (_size < current) {
+          found = true;
+          break;
+      }
+      count++;
+  }
+
+  if (count >= units) {
+      count = (units - 1);
+  }
+
+  qreal devider = current/baseVal;
+  _size = _size/devider;
+
+  if (!positiveValue) {
+      _size *= -1.0;
+  }
+
+  ret.first = _size;
+  ret.second = (_unitSystem == 10) ? decimalUnits.at(count) : binaryUnits.at(count);
+
+  return ret;
+}
+
 Cutelee::SafeString Cutelee::toString(const QVariantList &list)
 {
   QString output(QLatin1Char('['));

--- a/templates/lib/util.h
+++ b/templates/lib/util.h
@@ -86,6 +86,16 @@ CUTELEE_TEMPLATES_EXPORT bool supportedOutputType(const QVariant &input);
 */
 CUTELEE_TEMPLATES_EXPORT bool equals(const QVariant &lhs, const QVariant &rhs);
 
+/**
+  Converts @p size into the nearest file size unit like MB or MiB, based on the
+  @p unitSystem value. Use @c 2 for the @p unitSystem to get binary units, use @c 10 to get
+  decimal units - by default, decimal units will be returned. The @p multiplier
+  can be used if the input @p size is not in pure bytes. If @p size is for example given
+  in @a KiB, use a multiplier of @a 1024.
+  The returned pair will have the converted size as @a first and the unit as @a second.
+*/
+CUTELEE_TEMPLATES_EXPORT std::pair<qreal,QString> calcFileSize(qreal size, int unitSystem = 10, qreal multiplier = 1.0);
+
 #ifndef Q_QDOC
 /**
   @internal

--- a/templates/tests/testfilters.cpp
+++ b/templates/tests/testfilters.cpp
@@ -985,6 +985,80 @@ void TestFilters::testStringFilters_data()
       << QStringLiteral("{% autoescape off %}{{ a|striptags }} {{ b|striptags "
                         "}}{% endautoescape %}")
       << dict << QStringLiteral("x y x y") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_int_mib"), 1048576);
+
+  QTest::newRow("filter-filesizeformat01")
+      << QStringLiteral("{{ fs_int_mib|filesizeformat }}") << dict
+      << QStringLiteral("1.05 MB") << NoError;
+
+  QTest::newRow("filter-filesizeformat02")
+      << QStringLiteral("{{ fs_int_mib|filesizeformat:\"2\" }}") << dict
+      << QStringLiteral("1.00 MiB") << NoError;
+
+  QTest::newRow("filter-filesizeformat03")
+      << QStringLiteral("{{ fs_int_mib|filesizeformat:\"10,3\" }}") << dict
+      << QStringLiteral("1.049 MB") << NoError;
+
+  QTest::newRow("filter-filesizeformat04")
+      << QStringLiteral("{{ fs_int_mib|filesizeformat:\"10,2,1024\" }}") << dict
+      << QStringLiteral("1.07 GB") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_float_mib"), 1024.5);
+
+  QTest::newRow("filter-filesizeformat05")
+      << QStringLiteral("{{ fs_float_mib|filesizeformat:\"10,2,1024\" }}") << dict
+      << QStringLiteral("1.05 MB") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_string_mib"), QStringLiteral("1024.5"));
+
+  QTest::newRow("filter-filesizeformat06")
+      << QStringLiteral("{{ fs_string_mib|filesizeformat:\"10,2,1024\" }}") << dict
+      << QStringLiteral("1.05 MB") << NoError;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_bytes"), 999);
+  dict.insert(QStringLiteral("fs_kb"), 1000);
+  dict.insert(QStringLiteral("fs_10kb"), 10 * 1000);
+  dict.insert(QStringLiteral("fs_1000kb"), 1000 * 1000 -1);
+  dict.insert(QStringLiteral("fs_mb"), 1000 * 1000);
+  dict.insert(QStringLiteral("fs_50mb"), 1000 * 1000 * 50);
+  dict.insert(QStringLiteral("fs_1000mb"), 1000 * 1000 * 1000 - 1);
+  dict.insert(QStringLiteral("fs_gb"), 1000 * 1000 * 1000);
+  dict.insert(QStringLiteral("fs_tb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0));
+  dict.insert(QStringLiteral("fs_pb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0));
+  dict.insert(QStringLiteral("fs_eb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 2000.0));
+  dict.insert(QStringLiteral("fs_zb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0));
+  dict.insert(QStringLiteral("fs_yb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0));
+  dict.insert(QStringLiteral("fs_2000yb"), static_cast<double>(1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 2000.0));
+  dict.insert(QStringLiteral("fs_0b1"), 0.1);
+  dict.insert(QStringLiteral("fs_0b2"), QString(QChar(0x03B1)));
+  dict.insert(QStringLiteral("fs_neg_1"), -100);
+  dict.insert(QStringLiteral("fs_neg_2"), -1000 * 1000 *50);
+
+  // fixes tests on MSVC2013
+  QString fsInput;
+  fsInput  = QStringLiteral("{{ fs_bytes|filesizeformat }} {{ fs_kb|filesizeformat }} {{ fs_10kb|filesizeformat }} {{ fs_1000kb|filesizeformat }} ");
+  fsInput += QStringLiteral("{{ fs_mb|filesizeformat }} {{ fs_50mb|filesizeformat }} {{ fs_1000mb|filesizeformat }} {{ fs_gb|filesizeformat }} ");
+  fsInput += QStringLiteral("{{ fs_tb|filesizeformat }} {{ fs_pb|filesizeformat }} {{ fs_eb|filesizeformat }} {{ fs_zb|filesizeformat }} ");
+  fsInput += QStringLiteral("{{ fs_yb|filesizeformat }} {{ fs_2000yb|filesizeformat }} {{ fs_0b1|filesizeformat }} {{ fs_0b2|filesizeformat }} ");
+  fsInput += QStringLiteral("{{ fs_neg_1|filesizeformat }} {{ fs_neg_2|filesizeformat }}");
+
+  QString fsExpect;
+  fsExpect  = QStringLiteral("999 bytes 1.00 KB 10.00 KB 1000.00 KB ");
+  fsExpect += QStringLiteral("1.00 MB 50.00 MB 1000.00 MB 1.00 GB ");
+  fsExpect += QStringLiteral("1.00 TB 1.00 PB 2.00 EB 1.00 ZB ");
+  fsExpect += QStringLiteral("1.00 YB 2000.00 YB 0 bytes 0 bytes ");
+  fsExpect += QStringLiteral("-100 bytes -50.00 MB");
+
+  QTest::newRow("filter-filesizeformat07")
+     << fsInput
+     << dict
+     << fsExpect
+     << NoError;
 }
 
 void TestFilters::testListFilters_data()

--- a/templates/tests/testinternationalization.cpp
+++ b/templates/tests/testinternationalization.cpp
@@ -609,6 +609,89 @@ void TestInternationalization::testLocalizedTemplate_data()
       << QStringLiteral("{{ 'this'|cut:_(\"i\") }}") << QStringLiteral("ths")
       << QStringLiteral("ths") << QStringLiteral("ths") << QStringLiteral("ths")
       << QStringLiteral("ths") << dict;
+
+  // Start testing l10n_filesizeformat
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_int_mib"), 1048576);
+
+  QTest::newRow("fragment-09")
+      << QStringLiteral("{% l10n_filesize fs_int_mib %}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
+
+  QTest::newRow("fragment-10")
+      << QStringLiteral("{% l10n_filesize_var fs_int_mib size_var %}{{ size_var }}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
+
+  QTest::newRow("fragment-11")
+      << QStringLiteral("{% l10n_filesize fs_int_mib 2 %}")
+      << QStringLiteral("1.00 MiB") << QStringLiteral("1.00 MiB")
+      << QStringLiteral("1.00 MiB") << QStringLiteral("1,00 MiB")
+      << QStringLiteral("1,00 MiB") << dict;
+
+  QTest::newRow("fragment-12")
+      << QStringLiteral("{% l10n_filesize_var fs_int_mib 2 size_var %}{{ size_var }}")
+      << QStringLiteral("1.00 MiB") << QStringLiteral("1.00 MiB")
+      << QStringLiteral("1.00 MiB") << QStringLiteral("1,00 MiB")
+      << QStringLiteral("1,00 MiB") << dict;
+
+  QTest::newRow("fragment-13")
+      << QStringLiteral("{% l10n_filesize fs_int_mib 10 3 %}")
+      << QStringLiteral("1.049 MB") << QStringLiteral("1.049 MB")
+      << QStringLiteral("1.049 MB") << QStringLiteral("1,049 MB")
+      << QStringLiteral("1,049 MB") << dict;
+
+  QTest::newRow("fragment-14")
+      << QStringLiteral("{% l10n_filesize_var fs_int_mib 10 3 size_var %}{{ size_var }}")
+      << QStringLiteral("1.049 MB") << QStringLiteral("1.049 MB")
+      << QStringLiteral("1.049 MB") << QStringLiteral("1,049 MB")
+      << QStringLiteral("1,049 MB") << dict;
+
+  QTest::newRow("fragment-15")
+      << QStringLiteral("{% l10n_filesize fs_int_mib 10 2 1024 %}")
+      << QStringLiteral("1.07 GB") << QStringLiteral("1.07 GB")
+      << QStringLiteral("1.07 GB") << QStringLiteral("1,07 GB")
+      << QStringLiteral("1,07 GB") << dict;
+
+  QTest::newRow("fragment-16")
+      << QStringLiteral("{% l10n_filesize_var fs_int_mib 10 2 1024 size_var %}{{ size_var }}")
+      << QStringLiteral("1.07 GB") << QStringLiteral("1.07 GB")
+      << QStringLiteral("1.07 GB") << QStringLiteral("1,07 GB")
+      << QStringLiteral("1,07 GB") << dict;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_float_mib"), 1024.5);
+
+  QTest::newRow("fragment-17")
+      << QStringLiteral("{% l10n_filesize fs_float_mib 10 2 1024 %}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
+
+  QTest::newRow("fragment-18")
+      << QStringLiteral("{% l10n_filesize_var fs_float_mib 10 2 1024 size_var %}{{ size_var }}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
+
+  dict.clear();
+  dict.insert(QStringLiteral("fs_string_mib"), QStringLiteral("1024.5"));
+
+  QTest::newRow("fragment-19")
+      << QStringLiteral("{% l10n_filesize fs_string_mib 10 2 1024 %}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
+
+  QTest::newRow("fragment-20")
+      << QStringLiteral("{% l10n_filesize_var fs_string_mib 10 2 1024 size_var %}{{ size_var }}")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
+      << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
+      << QStringLiteral("1,05 MB") << dict;
 }
 
 void TestInternationalization::testSafeContent()

--- a/templates/tests/testinternationalization.cpp
+++ b/templates/tests/testinternationalization.cpp
@@ -611,6 +611,9 @@ void TestInternationalization::testLocalizedTemplate_data()
       << QStringLiteral("ths") << dict;
 
   // Start testing l10n_filesizeformat
+  // If build against Qt 5.10 or newer, internally QLocale::formattedDataSize() will be used
+  // for values that fit into a qint64. QLocale also supports translating the unit name,
+  // that is the reason why test results differ for Qt version before and after 5.10
 
   dict.clear();
   dict.insert(QStringLiteral("fs_int_mib"), 1048576);
@@ -619,49 +622,89 @@ void TestInternationalization::testLocalizedTemplate_data()
       << QStringLiteral("{% l10n_filesize fs_int_mib %}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-10")
       << QStringLiteral("{% l10n_filesize_var fs_int_mib size_var %}{{ size_var }}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-11")
       << QStringLiteral("{% l10n_filesize fs_int_mib 2 %}")
       << QStringLiteral("1.00 MiB") << QStringLiteral("1.00 MiB")
       << QStringLiteral("1.00 MiB") << QStringLiteral("1,00 MiB")
-      << QStringLiteral("1,00 MiB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,00 Mio")
+#else
+      << QStringLiteral("1,00 MiB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-12")
       << QStringLiteral("{% l10n_filesize_var fs_int_mib 2 size_var %}{{ size_var }}")
       << QStringLiteral("1.00 MiB") << QStringLiteral("1.00 MiB")
       << QStringLiteral("1.00 MiB") << QStringLiteral("1,00 MiB")
-      << QStringLiteral("1,00 MiB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,00 Mio")
+#else
+      << QStringLiteral("1,00 MiB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-13")
       << QStringLiteral("{% l10n_filesize fs_int_mib 10 3 %}")
       << QStringLiteral("1.049 MB") << QStringLiteral("1.049 MB")
       << QStringLiteral("1.049 MB") << QStringLiteral("1,049 MB")
-      << QStringLiteral("1,049 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,049 Mo")
+#else
+      << QStringLiteral("1,049 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-14")
       << QStringLiteral("{% l10n_filesize_var fs_int_mib 10 3 size_var %}{{ size_var }}")
       << QStringLiteral("1.049 MB") << QStringLiteral("1.049 MB")
       << QStringLiteral("1.049 MB") << QStringLiteral("1,049 MB")
-      << QStringLiteral("1,049 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,049 Mo")
+#else
+      << QStringLiteral("1,049 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-15")
       << QStringLiteral("{% l10n_filesize fs_int_mib 10 2 1024 %}")
       << QStringLiteral("1.07 GB") << QStringLiteral("1.07 GB")
       << QStringLiteral("1.07 GB") << QStringLiteral("1,07 GB")
-      << QStringLiteral("1,07 GB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,07 Go")
+#else
+      << QStringLiteral("1,07 GB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-16")
       << QStringLiteral("{% l10n_filesize_var fs_int_mib 10 2 1024 size_var %}{{ size_var }}")
       << QStringLiteral("1.07 GB") << QStringLiteral("1.07 GB")
       << QStringLiteral("1.07 GB") << QStringLiteral("1,07 GB")
-      << QStringLiteral("1,07 GB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,07 Go")
+#else
+      << QStringLiteral("1,07 GB")
+#endif
+      << dict;
 
   dict.clear();
   dict.insert(QStringLiteral("fs_float_mib"), 1024.5);
@@ -670,13 +713,23 @@ void TestInternationalization::testLocalizedTemplate_data()
       << QStringLiteral("{% l10n_filesize fs_float_mib 10 2 1024 %}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-18")
       << QStringLiteral("{% l10n_filesize_var fs_float_mib 10 2 1024 size_var %}{{ size_var }}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 
   dict.clear();
   dict.insert(QStringLiteral("fs_string_mib"), QStringLiteral("1024.5"));
@@ -685,13 +738,23 @@ void TestInternationalization::testLocalizedTemplate_data()
       << QStringLiteral("{% l10n_filesize fs_string_mib 10 2 1024 %}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 
   QTest::newRow("fragment-20")
       << QStringLiteral("{% l10n_filesize_var fs_string_mib 10 2 1024 size_var %}{{ size_var }}")
       << QStringLiteral("1.05 MB") << QStringLiteral("1.05 MB")
       << QStringLiteral("1.05 MB") << QStringLiteral("1,05 MB")
-      << QStringLiteral("1,05 MB") << dict;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+      << QStringLiteral("1,05 Mo")
+#else
+      << QStringLiteral("1,05 MB")
+#endif
+      << dict;
 }
 
 void TestInternationalization::testSafeContent()


### PR DESCRIPTION
This implements the filesizeformat filter as it is available in Django (plus some optional features). Additionally it introduces two new tags (l10n_filesize and l10n_filesize_var) for the i18n system to support file sizes with localized number strings.

Originally from: https://github.com/steveire/grantlee/pull/36