### PR TITLE
Fix Engine::insertLibrary() and add a test for it

### DIFF
--- a/templates/lib/engine.cpp
+++ b/templates/lib/engine.cpp
@@ -225,6 +225,7 @@ void Engine::insertLibrary(const QString &name, TagLibraryInterface *lib)
 {
     Q_D(Engine);
     auto ptr = PluginPointer<TagLibraryInterface>(lib);
+    d->m_defaultLibraries << name;
     d->m_libraries.insert(name, ptr);
 }
 

--- a/templates/lib/engine.cpp
+++ b/templates/lib/engine.cpp
@@ -225,8 +225,14 @@ void Engine::insertLibrary(const QString &name, TagLibraryInterface *lib)
 {
     Q_D(Engine);
     auto ptr = PluginPointer<TagLibraryInterface>(lib);
-    d->m_defaultLibraries << name;
     d->m_libraries.insert(name, ptr);
+}
+
+void Engine::insertDefaultLibrary(const QString &name, TagLibraryInterface *lib)
+{
+    Q_D(Engine);
+    insertLibrary(name, lib);
+    d->m_defaultLibraries << name;
 }
 
 TagLibraryInterface *EnginePrivate::loadLibrary(const QString &name,

--- a/templates/lib/engine.h
+++ b/templates/lib/engine.h
@@ -232,9 +232,22 @@ public:
   void setSmartTrimEnabled(bool enabled);
 
   /**
-   * Inserts the tag library without requiring to load a plugin
+   * Inserts the tag library @p lib without requiring to load a plugin.
+   *
+   * In your template you need to use {% load name %} to make the tags and
+   * filters of this library available.
+   *
+   * @sa insertDefaultLibrary
    */
   void insertLibrary(const QString &name, TagLibraryInterface *lib);
+
+  /**
+   * Inserts the tag library @p lib without requiring to load a plugin and adds it to
+   * the list of libraries available by default to new Templates.
+   *
+   * @sa insertLibrary
+   */
+  void insertDefaultLibrary(const QString &name, TagLibraryInterface *lib);
 
 #ifndef Q_QDOC
   /**

--- a/templates/tests/CMakeLists.txt
+++ b/templates/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ cutelee_templates_unit_tests(
   testfilters
   testgenerictypes
   testgenericcontainers
+  testinsertlibrary
 )
 
 if (Qt5Qml_FOUND)

--- a/templates/tests/testinsertlibrary.cpp
+++ b/templates/tests/testinsertlibrary.cpp
@@ -22,6 +22,7 @@
 #define INSERTLIBRARYTEST_H
 
 #include <QTest>
+#include <QDebug>
 
 #include "coverageobject.h"
 #include "engine.h"

--- a/templates/tests/testinsertlibrary.cpp
+++ b/templates/tests/testinsertlibrary.cpp
@@ -106,8 +106,6 @@ void TestInsertLibrary::initTestCase()
     m_engine->setPluginPaths({QStringLiteral(CUTELEE_PLUGIN_PATH)});
 
     m_engine->insertLibrary(QStringLiteral("test_library"), new TestLibrary(m_engine));
-
-    qDebug() << m_engine->defaultLibraries();
 }
 
 void TestInsertLibrary::cleanupTestCase()

--- a/templates/tests/testinsertlibrary.cpp
+++ b/templates/tests/testinsertlibrary.cpp
@@ -1,0 +1,137 @@
+/*
+ * This file is part of the Cutelee template system.
+ *
+ * Copyright (c) 2020 Matthias Fehring <mf@huessenbergnetz.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either version
+ * 2.1 of the Licence, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef INSERTLIBRARYTEST_H
+#define INSERTLIBRARYTEST_H
+
+#include <QTest>
+
+#include "coverageobject.h"
+#include "engine.h"
+#include "cutelee_paths.h"
+#include "template.h"
+#include "node.h"
+#include "parser.h"
+#include "taglibraryinterface.h"
+#include "exception.h"
+
+#define TESTLIBRARYTAG_RENDER_VALUE "Hello World!"
+
+using namespace Cutelee;
+
+class TestInsertLibrary : public CoverageObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+
+    void testInsertedLibraryTag();
+
+private:
+    QSharedPointer<InMemoryTemplateLoader> m_loader;
+    Engine *m_engine = nullptr;
+};
+
+class TestLibraryTagFactory : public AbstractNodeFactory
+{
+    Node *getNode(const QString &tagContent, Parser *p) const override;
+};
+
+class TestLibraryTag : public Node
+{
+    Q_OBJECT
+public:
+    explicit TestLibraryTag(Parser *parser = nullptr) : Node(parser) {}
+
+    void render(Cutelee::OutputStream *stream, Cutelee::Context *gc) const override;
+};
+
+Node *TestLibraryTagFactory::getNode(const QString &tagContent, Parser *p) const
+{
+    Q_UNUSED(tagContent)
+    return new TestLibraryTag(p);
+}
+
+void TestLibraryTag::render(Cutelee::OutputStream *stream, Cutelee::Context *gc) const
+{
+    Q_UNUSED(gc);
+    *stream << QStringLiteral(TESTLIBRARYTAG_RENDER_VALUE);
+}
+
+class TestLibrary : public QObject, public TagLibraryInterface
+{
+    Q_OBJECT
+    Q_INTERFACES(Cutelee::TagLibraryInterface)
+public:
+    explicit TestLibrary(QObject *parent = nullptr) : QObject(parent) {}
+
+    virtual QHash<QString, AbstractNodeFactory*> nodeFactories(const QString &name = QString()) override
+    {
+        Q_UNUSED(name);
+        QHash<QString, AbstractNodeFactory*> ret{
+            {QStringLiteral("test_library_tag"), new TestLibraryTagFactory()}
+        };
+        return ret;
+    }
+};
+
+void TestInsertLibrary::initTestCase()
+{
+    m_engine = new Engine(this);
+    QVERIFY(m_engine);
+
+    m_loader = QSharedPointer<InMemoryTemplateLoader>(new InMemoryTemplateLoader());
+    m_engine->addTemplateLoader(m_loader);
+
+    m_engine->setPluginPaths({QStringLiteral(CUTELEE_PLUGIN_PATH)});
+
+    m_engine->insertLibrary(QStringLiteral("test_library"), new TestLibrary(m_engine));
+
+    qDebug() << m_engine->defaultLibraries();
+}
+
+void TestInsertLibrary::cleanupTestCase()
+{
+    delete m_engine;
+}
+
+void TestInsertLibrary::testInsertedLibraryTag()
+{
+    auto t = m_engine->newTemplate(QStringLiteral("{% test_library_tag %}"), QStringLiteral("testInsertedLibraryTag"));
+
+    Context context;
+
+    const QString result = t->render(&context);
+
+    if (t->error() != NoError) {
+        qDebug() << t->errorString();
+    }
+
+    QCOMPARE(t->error(), NoError);
+    QCOMPARE(result, QStringLiteral(TESTLIBRARYTAG_RENDER_VALUE));
+}
+
+QTEST_MAIN(TestInsertLibrary)
+
+#include "testinsertlibrary.moc"
+
+#endif // INSERTLIBRARYTEST_H


### PR DESCRIPTION
Inserting a library directly with the new insertLibrary() function added the library to the list of already loaded libraries (EnginePrivate::m_libraries), but the Parser uses the return value of Engine::defaultLibraries() to load the tags and filters of each library.

https://github.com/cutelyst/cutelee/blob/33b629a6af6168a5eedd1be79b90cb3187b35a57/templates/lib/parser.cpp#L90-L109

So the tag or filter from the inserted library can not be found by the parser and it throws an error like: `Error while rendering template: Invalid block tag on line 0: 'my_nice_tag''. Did you forget to register or load this tag?`

Adding the name of the inserted library to the list of default libraries (EnginePrivate::m_defaultLibraries) fixes this issue.

I think that should be fine as Engine::loadDefaultLibraries() and Engine::loadLibrary() both check if the library has already been loaded. We might could change the name of insertLibrary() to
insertDefaultLibrary() to make it more clear that it also populates the list of default libraries.

I would like you to review it. Is only a one liner, but your understanding of the code might be better than mine. :)