### PR TITLE
Make enums comparable

### DIFF
--- a/templates/lib/customtyperegistry.cpp
+++ b/templates/lib/customtyperegistry.cpp
@@ -38,6 +38,7 @@ CustomTypeRegistry::CustomTypeRegistry()
   // Cutelee Types
   registerBuiltInMetatype<SafeString>();
   registerBuiltInMetatype<MetaEnumVariable>();
+  QMetaType::registerComparators<MetaEnumVariable>();
 }
 
 void CustomTypeRegistry::registerLookupOperator(int id,

--- a/templates/lib/metaenumvariable_p.h
+++ b/templates/lib/metaenumvariable_p.h
@@ -44,6 +44,13 @@ struct MetaEnumVariable {
 
   bool operator==(int otherValue) const { return value == otherValue; }
 
+  bool operator<(const MetaEnumVariable &other) const
+  {
+    return value < other.value;
+  }
+
+  bool operator<(int otherValue) const { return value < otherValue; }
+
   QMetaEnum enumerator;
   int value;
 };


### PR DESCRIPTION
I thought enums were already comparable, but this only applied to the equality operator, not for less than etc. My unit tests for the comparison operators were successfully completed, but this was apparently rather coincidental.

This now adds the missing comparison operators to MetaEnumVariable and registers them with QMetaType::registerComparators().