### PR TITLE
Qt JSON types support

### DIFF
--- a/templates/lib/variable.cpp
+++ b/templates/lib/variable.cpp
@@ -29,6 +29,10 @@
 
 #include <QtCore/QMetaEnum>
 #include <QtCore/QStringList>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
 
 using namespace Cutelee;
 
@@ -206,6 +210,42 @@ QVariant Variable::resolve(Context *c) const
 
     } else {
       var = c->lookup(d->m_lookups.at(i++));
+      if (var.userType() == QMetaType::QJsonDocument) {
+          const auto jsonDoc = var.toJsonDocument();
+          if (jsonDoc.isArray()) {
+              var = jsonDoc.array().toVariantList();
+          } else if (jsonDoc.isObject()) {
+              var = jsonDoc.object().toVariantHash();
+          } else {
+              // JSON document is eather empty or null
+              return QVariant();
+          }
+      } else if (var.userType() == QMetaType::QJsonValue) {
+          const auto jsonVal = var.toJsonValue();
+          switch(jsonVal.type()) {
+          case QJsonValue::Bool:
+              var = jsonVal.toBool();
+              break;
+          case QJsonValue::Double:
+              var = jsonVal.toDouble();
+              break;
+          case QJsonValue::String:
+              var = jsonVal.toString();
+              break;
+          case QJsonValue::Array:
+              var = jsonVal.toArray().toVariantList();
+              break;
+          case QJsonValue::Object:
+              var = jsonVal.toObject().toVariantHash();
+              break;
+          default:
+              return QVariant();
+          }
+      } else if (var.userType() == QMetaType::QJsonArray) {
+          var = var.toJsonArray().toVariantList();
+      } else if (var.userType() == QMetaType::QJsonObject) {
+          var = var.toJsonObject().toVariantHash();
+      }
     }
     while (i < d->m_lookups.size()) {
       var = MetaType::lookup(var, d->m_lookups.at(i++));

--- a/templates/lib/variable.cpp
+++ b/templates/lib/variable.cpp
@@ -233,10 +233,8 @@ QVariant Variable::resolve(Context *c) const
               var = jsonVal.toString();
               break;
           case QJsonValue::Array:
-              var = jsonVal.toArray().toVariantList();
-              break;
           case QJsonValue::Object:
-              var = jsonVal.toObject().toVariantHash();
+              var = jsonVal.toVariant();
               break;
           default:
               return QVariant();


### PR DESCRIPTION
This adds support for Qt’s JSON types (QJsonDocument, QJsonObject, QJsonArray, QJsonValue) as proposed in the comment of PR #5.

The difficulty in using Qt’s JSON data types was that they can be casted to QVariantList/QVariantHash if they are inside a QVariant and e.g. `QVariant::canConvert<QVariantList>` returns `true` for a QJsonArray, but the next step by Cutelee is to cast them into QAssociativeIterable or QSequentialIterable. That only works for template based containers and ends with a segfault for the JSON types.

So, my solution is to “intercept“ this types before the QVariant cast is tried and convert them directly into QVariantList or QVariantHash. If the JSON type is direct part of the context, this happens in `Cutelee::Variable::resolve()`, if the JSON type is stored in a context variable’s property or further down the road, the lookup will be done in `Cutelee::MetaType::lookup()`.

Unit tests are currently written to test “normal“ usage as variable and to be used in a `{% for %}` loop tag. Maybe we should add some more tests to see if they play nicely with filters and the rest, even though I think that this implementations should make this possible without further changes.