### PR TITLE
Fix ifchanged tag on Qt6 (closes #10)

### DIFF
--- a/templates/defaulttags/ifchanged.cpp
+++ b/templates/defaulttags/ifchanged.cpp
@@ -97,12 +97,20 @@ void IfChangedNode::render(OutputStream *stream, Context *c) const
     watchedVars.append(var);
   }
 
+  // In Qt6, QVariant::value<QVariantList>() converts a QString
+  // to a QList(QVariant(QChar, c)...).
+  // Avoid that conversion
+  QVariantList lastSeenVarList;
+  if (m_lastSeen.userType() != qMetaTypeId<QString>()) {
+      lastSeenVarList = m_lastSeen.value<QVariantList>();
+  }
+
   // At first glance it looks like m_last_seen will always be invalid,
   // But it will change because render is called multiple times by the parent
   // {% for %} loop in the template.
-  if ((watchedVars != m_lastSeen.value<QVariantList>())
-      || (!watchedString.isEmpty()
-          && (watchedString != m_lastSeen.toString()))) {
+  if ((watchedVars != lastSeenVarList)
+       || (!watchedString.isEmpty()
+           && (watchedString != m_lastSeen.value<QString>()))) {
     auto firstLoop = !m_lastSeen.isValid();
     if (!watchedString.isEmpty())
       m_lastSeen = watchedString;


### PR DESCRIPTION
In Qt6, QVariant::value<QVariantList>() converts a QString to a QList(QVariant(QChar, c)...). Avoid that conversion.

Solution is taken from upstream Grantlee.