### PR TITLE
Include Qt major version into library file and dir names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(Cutelee_MAJOR_MINOR_VERSION_STRING "${Cutelee_VERSION_MAJOR}.${Cutelee_VERSI
 set (LIB_SUFFIX "" CACHE STRING "Define suffix of library directory name (eg. '64')")
 
 set( LIB_INSTALL_DIR lib${LIB_SUFFIX} )
-set( PLUGIN_INSTALL_DIR ${LIB_INSTALL_DIR}/cutelee/${Cutelee_MAJOR_MINOR_VERSION_STRING} )
+set( PLUGIN_INSTALL_DIR ${LIB_INSTALL_DIR}/cutelee-qt${QT_VERSION_MAJOR}/${Cutelee_MAJOR_MINOR_VERSION_STRING} )
 
 # set up RPATH/install_name_dir
 set( CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR})

--- a/cmake/modules/CuteleeMacros.cmake
+++ b/cmake/modules/CuteleeMacros.cmake
@@ -4,16 +4,16 @@ include(CMakeParseArguments)
 macro(cutelee_adjust_plugin_name pluginname)
   set_target_properties(${pluginname}
     PROPERTIES PREFIX ""
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/cutelee/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/cutelee/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/cutelee-qt${QT_VERSION_MAJOR}/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/cutelee-qt${QT_VERSION_MAJOR}/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
     DEBUG_POSTFIX "d"
   )
   foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${cfg} CFG)
     set_target_properties(${pluginname}
       PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_BINARY_DIR}/cutelee/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
-      RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_BINARY_DIR}/cutelee/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
+      LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_BINARY_DIR}/cutelee-qt${QT_VERSION_MAJOR}/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
+      RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_BINARY_DIR}/cutelee-qt${QT_VERSION_MAJOR}/${Cutelee_VERSION_MAJOR}.${Cutelee_VERSION_MINOR}"
       )
   endforeach()
 endmacro()

--- a/templates/lib/CMakeLists.txt
+++ b/templates/lib/CMakeLists.txt
@@ -38,7 +38,7 @@ set(cutelee_templates_HEADERS
   variable.h
 )
 
-add_library(Cutelee_Templates SHARED
+add_library(CuteleeQt${QT_VERSION_MAJOR}Templates SHARED
   abstractlocalizer.cpp
   cachingloaderdecorator.cpp
   customtyperegistry.cpp
@@ -78,12 +78,12 @@ add_library(Cutelee_Templates SHARED
   ${cutelee_templates_HEADERS}
 )
 
-add_library(Cutelee::Templates ALIAS Cutelee_Templates)
-generate_export_header(Cutelee_Templates)
-set_property(TARGET Cutelee_Templates PROPERTY
+add_library(Cutelee::Templates ALIAS CuteleeQt${QT_VERSION_MAJOR}Templates)
+generate_export_header(CuteleeQt${QT_VERSION_MAJOR}Templates)
+set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY
   EXPORT_NAME Templates
 )
-target_compile_features(Cutelee_Templates
+target_compile_features(CuteleeQt${QT_VERSION_MAJOR}Templates
   PRIVATE
     cxx_auto_type
   PUBLIC
@@ -92,18 +92,18 @@ target_compile_features(Cutelee_Templates
 
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
 
-  set_property(TARGET Cutelee_Templates PROPERTY DEBUG_POSTFIX "d")
+  set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY DEBUG_POSTFIX "d")
 
   foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${cfg} CFG)
-    set_target_properties(Cutelee_Templates
+    set_target_properties(CuteleeQt${QT_VERSION_MAJOR}Templates
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       )
   endforeach()
 endif()
-target_compile_definitions(Cutelee_Templates
+target_compile_definitions(CuteleeQt${QT_VERSION_MAJOR}Templates
   PRIVATE
     PLUGINS_PREFER_DEBUG_POSTFIX=$<CONFIG:Debug>
 )
@@ -125,9 +125,9 @@ if (Qml_FOUND)
     list(APPEND scriptabletags_SRCS ${CMAKE_SOURCE_DIR}/templates/scriptabletags/${file})
   endforeach()
 
-  target_sources(Cutelee_Templates PRIVATE ${scriptabletags_SRCS})
-  target_include_directories(Cutelee_Templates PRIVATE ../scriptabletags)
-  target_link_libraries(Cutelee_Templates
+  target_sources(CuteleeQt${QT_VERSION_MAJOR}Templates PRIVATE ${scriptabletags_SRCS})
+  target_include_directories(CuteleeQt${QT_VERSION_MAJOR}Templates PRIVATE ../scriptabletags)
+  target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}Templates
     PRIVATE Qt${QT_VERSION_MAJOR}::Qml
   )
 endif()
@@ -138,22 +138,22 @@ endif()
 
 configure_file(cutelee_test_export.h.in "${CMAKE_CURRENT_BINARY_DIR}/cutelee_test_export.h")
 
-target_link_libraries(Cutelee_Templates
+target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}Templates
   LINK_PUBLIC Qt${QT_VERSION_MAJOR}::Core
 )
 
-set_target_properties(Cutelee_Templates PROPERTIES
+set_target_properties(CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTIES
   VERSION    ${Cutelee_VERSION}
   SOVERSION  ${Cutelee_VERSION_MAJOR}
 )
 
-target_include_directories(Cutelee_Templates PUBLIC
+target_include_directories(CuteleeQt${QT_VERSION_MAJOR}Templates PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/cutelee${PROJECT_VERSION_MAJOR}-qt${QT_VERSION_MAJOR}>
 )
 
-set_property(TARGET Cutelee_Templates PROPERTY PUBLIC_HEADER ${cutelee_templates_HEADERS})
-install(TARGETS Cutelee_Templates EXPORT cutelee_targets
+set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY PUBLIC_HEADER ${cutelee_templates_HEADERS})
+install(TARGETS CuteleeQt${QT_VERSION_MAJOR}Templates EXPORT cutelee_targets
   RUNTIME DESTINATION bin COMPONENT Templates
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Templates
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Templates

--- a/templates/lib/CMakeLists.txt
+++ b/templates/lib/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} 5.6.0 COMPONENTS Core REQUIRED)
 
+set(templates_target_name CuteleeQt${QT_VERSION_MAJOR}Templates)
+
 configure_file(cutelee_version.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/cutelee_version.h)
 
 set(Cutelee_PLUGIN_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR} )
@@ -38,7 +40,7 @@ set(cutelee_templates_HEADERS
   variable.h
 )
 
-add_library(CuteleeQt${QT_VERSION_MAJOR}Templates SHARED
+add_library(${templates_target_name} SHARED
   abstractlocalizer.cpp
   cachingloaderdecorator.cpp
   customtyperegistry.cpp
@@ -78,12 +80,12 @@ add_library(CuteleeQt${QT_VERSION_MAJOR}Templates SHARED
   ${cutelee_templates_HEADERS}
 )
 
-add_library(Cutelee::Templates ALIAS CuteleeQt${QT_VERSION_MAJOR}Templates)
-generate_export_header(CuteleeQt${QT_VERSION_MAJOR}Templates)
-set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY
+add_library(Cutelee::Templates ALIAS ${templates_target_name})
+generate_export_header(${templates_target_name})
+set_property(TARGET ${templates_target_name} PROPERTY
   EXPORT_NAME Templates
 )
-target_compile_features(CuteleeQt${QT_VERSION_MAJOR}Templates
+target_compile_features(${templates_target_name}
   PRIVATE
     cxx_auto_type
   PUBLIC
@@ -92,18 +94,18 @@ target_compile_features(CuteleeQt${QT_VERSION_MAJOR}Templates
 
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
 
-  set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY DEBUG_POSTFIX "d")
+  set_property(TARGET ${templates_target_name} PROPERTY DEBUG_POSTFIX "d")
 
   foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${cfg} CFG)
-    set_target_properties(CuteleeQt${QT_VERSION_MAJOR}Templates
+    set_target_properties(${templates_target_name}
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       )
   endforeach()
 endif()
-target_compile_definitions(CuteleeQt${QT_VERSION_MAJOR}Templates
+target_compile_definitions(${templates_target_name}
   PRIVATE
     PLUGINS_PREFER_DEBUG_POSTFIX=$<CONFIG:Debug>
 )
@@ -125,9 +127,9 @@ if (Qml_FOUND)
     list(APPEND scriptabletags_SRCS ${CMAKE_SOURCE_DIR}/templates/scriptabletags/${file})
   endforeach()
 
-  target_sources(CuteleeQt${QT_VERSION_MAJOR}Templates PRIVATE ${scriptabletags_SRCS})
-  target_include_directories(CuteleeQt${QT_VERSION_MAJOR}Templates PRIVATE ../scriptabletags)
-  target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}Templates
+  target_sources(${templates_target_name} PRIVATE ${scriptabletags_SRCS})
+  target_include_directories(${templates_target_name} PRIVATE ../scriptabletags)
+  target_link_libraries(${templates_target_name}
     PRIVATE Qt${QT_VERSION_MAJOR}::Qml
   )
 endif()
@@ -138,22 +140,22 @@ endif()
 
 configure_file(cutelee_test_export.h.in "${CMAKE_CURRENT_BINARY_DIR}/cutelee_test_export.h")
 
-target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}Templates
+target_link_libraries(${templates_target_name}
   LINK_PUBLIC Qt${QT_VERSION_MAJOR}::Core
 )
 
-set_target_properties(CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTIES
+set_target_properties(${templates_target_name} PROPERTIES
   VERSION    ${Cutelee_VERSION}
   SOVERSION  ${Cutelee_VERSION_MAJOR}
 )
 
-target_include_directories(CuteleeQt${QT_VERSION_MAJOR}Templates PUBLIC
+target_include_directories(${templates_target_name} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/cutelee${PROJECT_VERSION_MAJOR}-qt${QT_VERSION_MAJOR}>
 )
 
-set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}Templates PROPERTY PUBLIC_HEADER ${cutelee_templates_HEADERS})
-install(TARGETS CuteleeQt${QT_VERSION_MAJOR}Templates EXPORT cutelee_targets
+set_property(TARGET ${templates_target_name} PROPERTY PUBLIC_HEADER ${cutelee_templates_HEADERS})
+install(TARGETS ${templates_target_name} EXPORT cutelee_targets
   RUNTIME DESTINATION bin COMPONENT Templates
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Templates
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Templates

--- a/textdocument/lib/CMakeLists.txt
+++ b/textdocument/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ set(cutelee_textdocument_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/cutelee_textdocument_export.h
 )
 
-add_library(Cutelee_TextDocument SHARED
+add_library(CuteleeQt${QT_VERSION_MAJOR}TextDocument SHARED
   bbcodebuilder.cpp
   markupdirector.cpp
   plaintextmarkupbuilder.cpp
@@ -20,23 +20,23 @@ add_library(Cutelee_TextDocument SHARED
   ${cutelee_textdocument_HEADERS}
 )
 
-generate_export_header(Cutelee_TextDocument)
-add_library(Cutelee::TextDocument ALIAS Cutelee_TextDocument)
-set_property(TARGET Cutelee_TextDocument PROPERTY
+generate_export_header(CuteleeQt${QT_VERSION_MAJOR}TextDocument)
+add_library(Cutelee::TextDocument ALIAS CuteleeQt${QT_VERSION_MAJOR}TextDocument)
+set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY
   EXPORT_NAME TextDocument
 )
-target_compile_features(Cutelee_TextDocument
+target_compile_features(CuteleeQt${QT_VERSION_MAJOR}TextDocument
   PRIVATE
     cxx_auto_type
   PUBLIC
     cxx_override
 )
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
-  set_property(TARGET Cutelee_TextDocument PROPERTY DEBUG_POSTFIX "d")
+  set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY DEBUG_POSTFIX "d")
 
   foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${cfg} CFG)
-    set_target_properties(Cutelee_TextDocument
+    set_target_properties(CuteleeQt${QT_VERSION_MAJOR}TextDocument
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
@@ -44,22 +44,22 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
   endforeach()
 endif()
 
-target_link_libraries(Cutelee_TextDocument
+target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}TextDocument
   PUBLIC Qt${QT_VERSION_MAJOR}::Gui
 )
 
-set_target_properties(Cutelee_TextDocument PROPERTIES
+set_target_properties(CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTIES
   VERSION    ${Cutelee_VERSION}
   SOVERSION  ${Cutelee_VERSION_MAJOR}
 )
 
-target_include_directories(Cutelee_TextDocument PUBLIC
+target_include_directories(CuteleeQt${QT_VERSION_MAJOR}TextDocument PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/cutelee${PROJECT_VERSION_MAJOR}-qt${QT_VERSION_MAJOR}>
 )
 
-set_property(TARGET Cutelee_TextDocument PROPERTY PUBLIC_HEADER ${cutelee_textdocument_HEADERS})
-install(TARGETS Cutelee_TextDocument EXPORT cutelee_targets
+set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY PUBLIC_HEADER ${cutelee_textdocument_HEADERS})
+install(TARGETS CuteleeQt${QT_VERSION_MAJOR}TextDocument EXPORT cutelee_targets
   RUNTIME DESTINATION bin COMPONENT TextDocument
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT TextDocument
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT TextDocument

--- a/textdocument/lib/CMakeLists.txt
+++ b/textdocument/lib/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(textdocs_target_name CuteleeQt${QT_VERSION_MAJOR}TextDocument)
+
 set(cutelee_textdocument_HEADERS
   cutelee_textdocument.h
   abstractmarkupbuilder.h
@@ -9,7 +11,7 @@ set(cutelee_textdocument_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/cutelee_textdocument_export.h
 )
 
-add_library(CuteleeQt${QT_VERSION_MAJOR}TextDocument SHARED
+add_library(${textdocs_target_name} SHARED
   bbcodebuilder.cpp
   markupdirector.cpp
   plaintextmarkupbuilder.cpp
@@ -20,23 +22,23 @@ add_library(CuteleeQt${QT_VERSION_MAJOR}TextDocument SHARED
   ${cutelee_textdocument_HEADERS}
 )
 
-generate_export_header(CuteleeQt${QT_VERSION_MAJOR}TextDocument)
-add_library(Cutelee::TextDocument ALIAS CuteleeQt${QT_VERSION_MAJOR}TextDocument)
-set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY
+generate_export_header(${textdocs_target_name})
+add_library(Cutelee::TextDocument ALIAS ${textdocs_target_name})
+set_property(TARGET ${textdocs_target_name} PROPERTY
   EXPORT_NAME TextDocument
 )
-target_compile_features(CuteleeQt${QT_VERSION_MAJOR}TextDocument
+target_compile_features(${textdocs_target_name}
   PRIVATE
     cxx_auto_type
   PUBLIC
     cxx_override
 )
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
-  set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY DEBUG_POSTFIX "d")
+  set_property(TARGET ${textdocs_target_name} PROPERTY DEBUG_POSTFIX "d")
 
   foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
     string(TOUPPER ${cfg} CFG)
-    set_target_properties(CuteleeQt${QT_VERSION_MAJOR}TextDocument
+    set_target_properties(${textdocs_target_name}
       PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
       RUNTIME_OUTPUT_DIRECTORY_${CFG} "${CMAKE_CURRENT_BINARY_DIR}"
@@ -44,22 +46,22 @@ if (CMAKE_GENERATOR MATCHES "Visual Studio")
   endforeach()
 endif()
 
-target_link_libraries(CuteleeQt${QT_VERSION_MAJOR}TextDocument
+target_link_libraries(${textdocs_target_name}
   PUBLIC Qt${QT_VERSION_MAJOR}::Gui
 )
 
-set_target_properties(CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTIES
+set_target_properties(${textdocs_target_name} PROPERTIES
   VERSION    ${Cutelee_VERSION}
   SOVERSION  ${Cutelee_VERSION_MAJOR}
 )
 
-target_include_directories(CuteleeQt${QT_VERSION_MAJOR}TextDocument PUBLIC
+target_include_directories(${textdocs_target_name} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/cutelee${PROJECT_VERSION_MAJOR}-qt${QT_VERSION_MAJOR}>
 )
 
-set_property(TARGET CuteleeQt${QT_VERSION_MAJOR}TextDocument PROPERTY PUBLIC_HEADER ${cutelee_textdocument_HEADERS})
-install(TARGETS CuteleeQt${QT_VERSION_MAJOR}TextDocument EXPORT cutelee_targets
+set_property(TARGET ${textdocs_target_name} PROPERTY PUBLIC_HEADER ${cutelee_textdocument_HEADERS})
+install(TARGETS ${textdocs_target_name} EXPORT cutelee_targets
   RUNTIME DESTINATION bin COMPONENT TextDocument
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT TextDocument
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT TextDocument


### PR DESCRIPTION
The current naming scheme prevents simultaneous installation for Qt5 and Qt6. This adds Qt5/6 to the generated file and directory names of the libraries and modules.