### PR TITLE
Fix generated export header file name

### DIFF
--- a/templates/lib/CMakeLists.txt
+++ b/templates/lib/CMakeLists.txt
@@ -81,7 +81,7 @@ add_library(${templates_target_name} SHARED
 )
 
 add_library(Cutelee::Templates ALIAS ${templates_target_name})
-generate_export_header(${templates_target_name})
+generate_export_header(${templates_target_name} BASE_NAME cutelee_templates)
 set_property(TARGET ${templates_target_name} PROPERTY
   EXPORT_NAME Templates
 )

--- a/textdocument/lib/CMakeLists.txt
+++ b/textdocument/lib/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(${textdocs_target_name} SHARED
   ${cutelee_textdocument_HEADERS}
 )
 
-generate_export_header(${textdocs_target_name})
+generate_export_header(${textdocs_target_name} BASE_NAME cutelee_textdocument)
 add_library(Cutelee::TextDocument ALIAS ${textdocs_target_name})
 set_property(TARGET ${textdocs_target_name} PROPERTY
   EXPORT_NAME TextDocument


### PR DESCRIPTION
After renaming the targets, the generated export header file name did not fit to the included file name. Set the BASE_NAME on CMake’s generate_export_header macro so that it fits again.