### PR TITLE
Fix formatting of some larger file sizes on 32bit x86 

### DIFF
--- a/templates/lib/util.cpp
+++ b/templates/lib/util.cpp
@@ -265,7 +265,6 @@ std::pair<qreal,QString> Cutelee::calcFileSize(qreal size, int unitSystem, qreal
                                            QStringLiteral("YB")
                                        });
 
-  bool found = false;
   int count = 0;
   const qreal baseVal = (_unitSystem == 10) ? 1000.0f : 1024.0f;
 #if FLT_EVAL_METHOD == 2
@@ -276,10 +275,9 @@ std::pair<qreal,QString> Cutelee::calcFileSize(qreal size, int unitSystem, qreal
   qreal current = 1.0f;
 #endif
   int units = decimalUnits.size();
-  while (!found && (count < units)) {
+  while (count < units) {
       current *= baseVal;
       if (_size < current) {
-          found = true;
           break;
       }
       count++;

--- a/templates/lib/util.cpp
+++ b/templates/lib/util.cpp
@@ -26,6 +26,8 @@
 #include <QtCore/QStringList>
 #include <QDebug>
 
+#include <cfloat>
+
 QString Cutelee::unescapeStringLiteral(const QString &input)
 {
   return input.mid(1, input.size() - 2)
@@ -266,7 +268,13 @@ std::pair<qreal,QString> Cutelee::calcFileSize(qreal size, int unitSystem, qreal
   bool found = false;
   int count = 0;
   const qreal baseVal = (_unitSystem == 10) ? 1000.0f : 1024.0f;
+#if FLT_EVAL_METHOD == 2
+  // Avoid that this is treated as long double, as the increased
+  // precision breaks the comparison below.
+  volatile qreal current = 1.0F;
+#else
   qreal current = 1.0f;
+#endif
   int units = decimalUnits.size();
   while (!found && (count < units)) {
       current *= baseVal;


### PR DESCRIPTION
With the x87 FPU available, GCC uses long double precision for some variables. Due to the function call passing a double, some comparisons break down. That resulted in "1.00 YB" being printed as "1000.00 ZB" instead.

Fix taken from https://github.com/steveire/grantlee/pull/86