### PR TITLE
Tests Workflow: ignore some paths on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - '**/codeqlqt6.yml'
+      - '**/*.md'
+      - '**/*.dox'
 
 env:
   BUILD_TYPE: Debug


### PR DESCRIPTION
Ignore the following paths on pull requests:
- '**/codeqlqt6.yml'
- '**/*.md'
- '**/*.dox'