### PR TITLE
Better support for QVariantMap

### DIFF
--- a/templates/lib/metatype.cpp
+++ b/templates/lib/metatype.cpp
@@ -216,7 +216,8 @@ QVariant Cutelee::MetaType::lookup(const QVariant &object,
 
     return iter.at(listIndex);
   }
-  if (object.canConvert<QVariantHash>()) {
+  if (object.canConvert<QVariantHash>() ||
+      object.canConvert<QVariantMap>()) {
 
     auto iter = object.value<QAssociativeIterable>();
 

--- a/templates/lib/util.cpp
+++ b/templates/lib/util.cpp
@@ -82,6 +82,9 @@ bool Cutelee::variantIsTrue(const QVariant &variant)
   case QMetaType::QVariantHash: {
     return !variant.value<QVariantHash>().isEmpty();
   }
+  case QMetaType::QVariantMap: {
+    return !variant.value<QVariantMap>().isEmpty();
+  }
   }
 
   return !getSafeString(variant).get().isEmpty();

--- a/templates/tests/testbuiltins.cpp
+++ b/templates/tests/testbuiltins.cpp
@@ -377,18 +377,24 @@ void TestBuiltinSyntax::testTruthiness_data()
     h.insert(QStringLiteral("value"), 1);
     QTest::newRow("truthtest-28") << QVariant::fromValue(h) << true;
   }
+  {
+    QVariantMap m;
+    QTest::newRow("truthtest-29") << QVariant::fromValue(m) << false;
+    m.insert(QStringLiteral("value"), 1);
+    QTest::newRow("truthtest-30") << QVariant::fromValue(m) << true;
+  }
 
   {
-    QTest::newRow("truthtest-29")
+    QTest::newRow("truthtest-31")
         << QVariant::fromValue<QObject *>(nullptr) << false;
     auto plainO = new QObject(this);
-    QTest::newRow("truthtest-30") << QVariant::fromValue(plainO) << true;
+    QTest::newRow("truthtest-32") << QVariant::fromValue(plainO) << true;
     auto trueO = new QObject(this);
     trueO->setProperty("__true__", true);
-    QTest::newRow("truthtest-31") << QVariant::fromValue(trueO) << true;
+    QTest::newRow("truthtest-33") << QVariant::fromValue(trueO) << true;
     auto falseO = new QObject(this);
     falseO->setProperty("__true__", false);
-    QTest::newRow("truthtest-32") << QVariant::fromValue(falseO) << false;
+    QTest::newRow("truthtest-34") << QVariant::fromValue(falseO) << false;
   }
 }
 
@@ -580,11 +586,21 @@ void TestBuiltinSyntax::testBasicSyntax_data()
   hash.clear();
   hash.insert(QStringLiteral("bar"), QStringLiteral("baz"));
   dict.insert(QStringLiteral("foo"), hash);
-  QTest::newRow("basic-syntax18") << QStringLiteral("{{ foo.bar }}") << dict
+  QTest::newRow("basic-syntax18a") << QStringLiteral("{{ foo.bar }}") << dict
                                   << QStringLiteral("baz") << NoError;
 
   // Fail silently when a variable's dictionary key isn't found
-  QTest::newRow("basic-syntax19")
+  QTest::newRow("basic-syntax19a")
+      << QStringLiteral("{{ foo.spam }}") << dict << QString() << NoError;
+
+  QVariantMap map;
+  map.insert(QStringLiteral("bar"), QStringLiteral("baz"));
+  dict.insert(QStringLiteral("foo"), map);
+  QTest::newRow("basic-syntax18b") << QStringLiteral("{{ foo.bar }}") << dict
+                                   << QStringLiteral("baz") << NoError;
+
+  // Fail silently when a variable's dictionary key isn't found
+  QTest::newRow("basic-syntax19a")
       << QStringLiteral("{{ foo.spam }}") << dict << QString() << NoError;
 
   dict.clear();

--- a/templates/tests/testdefaulttags.cpp
+++ b/templates/tests/testdefaulttags.cpp
@@ -1018,48 +1018,59 @@ void TestDefaultTags::testIfTag_data()
   QTest::newRow("if-truthiness04")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
+  QVariantMap map;
+  dict.insert(QStringLiteral("var"), map);
+  QTest::newRow("if-truthiness05")
+      << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
+      << QStringLiteral("No") << NoError;
+  map.insert(QStringLiteral("foo"), QStringLiteral("bar"));
+  dict.insert(QStringLiteral("var"), map);
+  QTest::newRow("if-truthiness06")
+      << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
+      << QStringLiteral("Yes") << NoError;
+
 
   QVariant var;
   dict.insert(QStringLiteral("var"), var);
-  QTest::newRow("if-truthiness05")
+  QTest::newRow("if-truthiness07")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("No") << NoError;
   var = QStringLiteral("foo");
   dict.insert(QStringLiteral("var"), var);
-  QTest::newRow("if-truthiness06")
+  QTest::newRow("if-truthiness08")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
 
   QString str;
   dict.insert(QStringLiteral("var"), str);
-  QTest::newRow("if-truthiness07")
+  QTest::newRow("if-truthiness09")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("No") << NoError;
   str = QStringLiteral("foo");
   dict.insert(QStringLiteral("var"), str);
-  QTest::newRow("if-truthiness08")
+  QTest::newRow("if-truthiness10")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
 
   auto i = 0;
   dict.insert(QStringLiteral("var"), i);
-  QTest::newRow("if-truthiness07")
+  QTest::newRow("if-truthiness11")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("No") << NoError;
   i = 7;
   dict.insert(QStringLiteral("var"), i);
-  QTest::newRow("if-truthiness08")
+  QTest::newRow("if-truthiness12")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
 
   auto r = 0.0;
   dict.insert(QStringLiteral("var"), r);
-  QTest::newRow("if-truthiness09")
+  QTest::newRow("if-truthiness13")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("No") << NoError;
   r = 7.1;
   dict.insert(QStringLiteral("var"), r);
-  QTest::newRow("if-truthiness10")
+  QTest::newRow("if-truthiness14")
       << QStringLiteral("{% if var %}Yes{% else %}No{% endif %}") << dict
       << QStringLiteral("Yes") << NoError;
 


### PR DESCRIPTION
QVariantMap has already been supported, but there was the truethiness check missing for it. This adds truethiness support for QVariantMap so that `{% if map %}use map{% endif %}` works as expected.

This also adds some more tests for QVariantMap.